### PR TITLE
Make Gerrit search query configurable

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -55,6 +55,12 @@ function handleMessage(message, sender, sendResponse){
 		case 'setGerritHost':
 			setGerritHost(message.host, sender.tab.id, sendResponse);
 			break;
+		case 'setGerritQuery':
+			setGerritQuery(message.query, sender.tab.id, sendResponse);
+			break;
+		case 'getGerritQuery':
+			getGerritQuery().then(query => sendResponse(query));
+			break;
 	}
 	return true;
 }
@@ -87,7 +93,9 @@ async function tryGetChangesByJiraKey(jiraKey, tabId, sendResponse){
 
 async function getChangesByJiraKey(jiraKey){
 	const gerritHost = await getGerritHost();
-	const response = await fetch(`https://${gerritHost}/a/changes/?q=tr:${jiraKey}&n=15`);
+	const queryTemplate = await getGerritQuery();
+	const query = queryTemplate.replace(/\$\{jiraKey\}/g, jiraKey);
+	const response = await fetch(`https://${gerritHost}/a/changes/?q=${encodeURIComponent(query)}&n=15`);
 
 	if (response.status !== 200){
 		return {
@@ -144,4 +152,17 @@ async function setGerritHost(host, tabId, sendResponse){
 async function getGerritHost(){
 	const data = await chrome.storage.local.get(['gerritHost']);
 	return data['gerritHost'];
+}
+
+const DEFAULT_GERRIT_QUERY = 'tr:${jiraKey}';
+
+async function setGerritQuery(query, tabId, sendResponse){
+	await chrome.storage.local.set({ gerritQuery: query });
+	sendResponse();
+	setListBadge('', tabId);
+}
+
+async function getGerritQuery(){
+	const data = await chrome.storage.local.get(['gerritQuery']);
+	return data['gerritQuery'] || DEFAULT_GERRIT_QUERY;
 }

--- a/lib/gerrit-jira-link.js
+++ b/lib/gerrit-jira-link.js
@@ -6,6 +6,8 @@
 
 	let localHostName = '';
 
+	let localGerritQuery = '';
+
 	let mostRecentUrl = '';
 
 	let mostRecentJiraKey = '';
@@ -55,7 +57,9 @@
 			)
 			{
 				const hostname = document.getElementById('gerrit-jira-gerrit-host-input').value;
+				const query = document.getElementById('gerrit-jira-gerrit-query-input').value;
 				setGerritHost(hostname);
+				setGerritQuery(query);
 				toggleOffNativePopup();
 			}
 		}
@@ -68,6 +72,7 @@
 		switch (message['type']){
 			case 'toggleNativePopup':
 				storeLocalHostName(message.host);
+				fetchLocalGerritQuery();
 				toggleNativePopupBasedOnLocalState();
 				break;
 			case 'setLastGerritResponse':
@@ -109,6 +114,14 @@
 		localHostName = hostName;
 	}
 
+	function fetchLocalGerritQuery(){
+		chrome.runtime.sendMessage({
+			type: 'getGerritQuery'
+		}, query => {
+			localGerritQuery = query;
+		});
+	}
+
 	function storeLocalChanges(fetchedChanges){
 		localChanges = fetchedChanges;
 		setBadgeToLength(localChanges.length);
@@ -134,6 +147,13 @@
 			type: 'setGerritHost',
 			host: hostname
 		}, fetchChangesIfJiraKeyDetected);
+	}
+
+	function setGerritQuery(query){
+		chrome.runtime.sendMessage({
+			type: 'setGerritQuery',
+			query: query
+		});
 	}
 
 
@@ -305,6 +325,11 @@
 					<img class="gerrit-jira-gerrit-icon" src="${iconUrl}" />
 					<b class="gerrit-jira-gerrit-host-label">Gerrit Host:</b>
 					<input id="gerrit-jira-gerrit-host-input" type="text" value="${localHostName ?? ''}" placeholder="your.gerrit.host"/>
+				</div>
+				<div class="gerrit-jira-settings-panel">
+					<img class="gerrit-jira-gerrit-icon" src="${iconUrl}" />
+					<b class="gerrit-jira-gerrit-host-label">Gerrit Query:</b>
+					<input id="gerrit-jira-gerrit-query-input" type="text" value="${localGerritQuery ?? ''}" placeholder="tr:${'$'}{jiraKey}"/>
 					<button class="gerrit-jira-settings-submit-button">Save</button>
 				</div>
 			</div>

--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,7 @@
   }],
 
   "background": {
-    "service_worker": "lib/background.js"
+    "service_worker": "lib/background.js",
+    "scripts": ["lib/background.js"]
   }
 }


### PR DESCRIPTION
Hello Joe,

Some of the teams I work on don't always use the `JIRA: ${jiraKey}` trailer format and instead prefix the subject line with the JIRA issue. I find this extension quite convenient so thought I'd propose an enhancement to allow the Gerrit query to be customized so it can be used with other commit conventions.

